### PR TITLE
ウィンドウ位置に合わせて音量バランスを変えるイベントメソッドを追加

### DIFF
--- a/src/PeerstPlayer/Controls/PecaPlayer/PecaPlayer.cs
+++ b/src/PeerstPlayer/Controls/PecaPlayer/PecaPlayer.cs
@@ -207,7 +207,7 @@ namespace PeerstPlayer.Controls.PecaPlayer
 		public bool UsedWMP { get { return moviePlayer is WindowsMediaPlayerControl; } }
 
 		/// <summary>
-		// ウィンドウ位置に応じて音量バランス変更
+		/// ウィンドウ位置に応じて音量バランス変更
 		/// </summary>
 		public bool VolumeBalanceByWindowPos { get; set; }
 

--- a/src/PeerstPlayer/Controls/PecaPlayer/PecaPlayer.cs
+++ b/src/PeerstPlayer/Controls/PecaPlayer/PecaPlayer.cs
@@ -206,6 +206,11 @@ namespace PeerstPlayer.Controls.PecaPlayer
 		/// </summary>
 		public bool UsedWMP { get { return moviePlayer is WindowsMediaPlayerControl; } }
 
+		/// <summary>
+		// ウィンドウ位置に応じて音量バランス変更
+		/// </summary>
+		public bool VolumeBalanceByWindowPos { get; set; }
+
 		//-------------------------------------------------------------
 		// 非公開プロパティ
 		//-------------------------------------------------------------

--- a/src/PeerstPlayer/Forms/Player/PlayerView.Designer.cs
+++ b/src/PeerstPlayer/Forms/Player/PlayerView.Designer.cs
@@ -104,10 +104,10 @@ namespace PeerstPlayer.Forms.Setting
 			this.toolStrip.Dock = System.Windows.Forms.DockStyle.None;
 			this.toolStrip.GripMargin = new System.Windows.Forms.Padding(0);
 			this.toolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.openViewerToolStripButton,
-			this.minToolStripButton,
-			this.maxToolStripButton,
-			this.closeToolStripButton});
+            this.openViewerToolStripButton,
+            this.minToolStripButton,
+            this.maxToolStripButton,
+            this.closeToolStripButton});
 			this.toolStrip.Location = new System.Drawing.Point(381, 0);
 			this.toolStrip.Name = "toolStrip";
 			this.toolStrip.Padding = new System.Windows.Forms.Padding(0);
@@ -195,34 +195,34 @@ namespace PeerstPlayer.Forms.Setting
 			// contextMenuStrip
 			// 
 			this.contextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.SizeToolStripMenuItem,
-			this.画面分割ToolStripMenuItem,
-			this.functionToolStripMenuItem,
-			this.volumeToolStripMenuItem,
-			this.settingToolStripMenuItem,
-			this.wmpMenuToolStripSeparator,
-			this.wmpMenuToolStripMenuItem,
-			this.showDebugToolStripMenuItem});
+            this.SizeToolStripMenuItem,
+            this.画面分割ToolStripMenuItem,
+            this.functionToolStripMenuItem,
+            this.volumeToolStripMenuItem,
+            this.settingToolStripMenuItem,
+            this.wmpMenuToolStripSeparator,
+            this.wmpMenuToolStripMenuItem,
+            this.showDebugToolStripMenuItem});
 			this.contextMenuStrip.Name = "contextMenuStrip";
 			this.contextMenuStrip.Size = new System.Drawing.Size(154, 186);
 			// 
 			// SizeToolStripMenuItem
 			// 
 			this.SizeToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.scale25PerToolStripMenuItem,
-			this.scale50PerToolStripMenuItem,
-			this.scale75PerToolStripMenuItem,
-			this.scale100PerToolStripMenuItem,
-			this.scale150PerToolStripMenuItem,
-			this.scale200PerToolStripMenuItem,
-			this.sizeToolStripSeparator,
-			this.size160x120ToolStripMenuItem,
-			this.size320x240ToolStripMenuItem,
-			this.size480x360ToolStripMenuItem,
-			this.size640x480ToolStripMenuItem,
-			this.size800x600ToolStripMenuItem,
-			this.fitMovieSizeToolStripSeparator,
-			this.fitMovieSizeToolStripMenuItem});
+            this.scale25PerToolStripMenuItem,
+            this.scale50PerToolStripMenuItem,
+            this.scale75PerToolStripMenuItem,
+            this.scale100PerToolStripMenuItem,
+            this.scale150PerToolStripMenuItem,
+            this.scale200PerToolStripMenuItem,
+            this.sizeToolStripSeparator,
+            this.size160x120ToolStripMenuItem,
+            this.size320x240ToolStripMenuItem,
+            this.size480x360ToolStripMenuItem,
+            this.size640x480ToolStripMenuItem,
+            this.size800x600ToolStripMenuItem,
+            this.fitMovieSizeToolStripSeparator,
+            this.fitMovieSizeToolStripMenuItem});
 			this.SizeToolStripMenuItem.Name = "SizeToolStripMenuItem";
 			this.SizeToolStripMenuItem.Size = new System.Drawing.Size(153, 22);
 			this.SizeToolStripMenuItem.Text = "サイズ";
@@ -312,15 +312,15 @@ namespace PeerstPlayer.Forms.Setting
 			// 画面分割ToolStripMenuItem
 			// 
 			this.画面分割ToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.screenSplitWidthx5ToolStripMenuItem,
-			this.screenSplitWidthx4ToolStripMenuItem,
-			this.screenSplitWidthx3ToolStripMenuItem,
-			this.screenSplitWidthx2ToolStripMenuItem,
-			this.screenSplitToolStripSeparator,
-			this.screenSplitHeightx5ToolStripMenuItem,
-			this.screenSplitHeightx4ToolStripMenuItem,
-			this.screenSplitHeightx3ToolStripMenuItem,
-			this.screenSplitHeightx2ToolStripMenuItem});
+            this.screenSplitWidthx5ToolStripMenuItem,
+            this.screenSplitWidthx4ToolStripMenuItem,
+            this.screenSplitWidthx3ToolStripMenuItem,
+            this.screenSplitWidthx2ToolStripMenuItem,
+            this.screenSplitToolStripSeparator,
+            this.screenSplitHeightx5ToolStripMenuItem,
+            this.screenSplitHeightx4ToolStripMenuItem,
+            this.screenSplitHeightx3ToolStripMenuItem,
+            this.screenSplitHeightx2ToolStripMenuItem});
 			this.画面分割ToolStripMenuItem.Name = "画面分割ToolStripMenuItem";
 			this.画面分割ToolStripMenuItem.Size = new System.Drawing.Size(153, 22);
 			this.画面分割ToolStripMenuItem.Text = "画面分割";
@@ -381,16 +381,16 @@ namespace PeerstPlayer.Forms.Setting
 			// functionToolStripMenuItem
 			// 
 			this.functionToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.topMostToolStripMenuItem,
-			this.updateChannelInfoToolStripMenuItem,
-			this.bumpToolStripMenuItem,
-			this.toolStripSeparator1,
-			this.screenshotToolStripMenuItem,
-			this.openScreenshotFolderToolStripMenuItem,
-			this.toolStripSeparator2,
-			this.openFromUrlToolStripMenuItem,
-			this.openFromFileToolStripMenuItem,
-			this.openFromClipboardToolStripMenuItem});
+            this.topMostToolStripMenuItem,
+            this.updateChannelInfoToolStripMenuItem,
+            this.bumpToolStripMenuItem,
+            this.toolStripSeparator1,
+            this.screenshotToolStripMenuItem,
+            this.openScreenshotFolderToolStripMenuItem,
+            this.toolStripSeparator2,
+            this.openFromUrlToolStripMenuItem,
+            this.openFromFileToolStripMenuItem,
+            this.openFromClipboardToolStripMenuItem});
 			this.functionToolStripMenuItem.Name = "functionToolStripMenuItem";
 			this.functionToolStripMenuItem.Size = new System.Drawing.Size(153, 22);
 			this.functionToolStripMenuItem.Text = "機能";
@@ -439,7 +439,7 @@ namespace PeerstPlayer.Forms.Setting
 			// openFromUrlToolStripMenuItem
 			// 
 			this.openFromUrlToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.openFromUrlToolStripTextBox});
+            this.openFromUrlToolStripTextBox});
 			this.openFromUrlToolStripMenuItem.Name = "openFromUrlToolStripMenuItem";
 			this.openFromUrlToolStripMenuItem.Size = new System.Drawing.Size(268, 22);
 			this.openFromUrlToolStripMenuItem.Text = "URLから開く";
@@ -467,15 +467,15 @@ namespace PeerstPlayer.Forms.Setting
 			// volumeToolStripMenuItem
 			// 
 			this.volumeToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.volumeUpToolStripMenuItem,
-			this.volumeDownToolStripMenuItem,
-			this.muteToolStripMenuItem,
-			this.volumeToolStripSeparator,
-			this.volumeBalanceLeftToolStripMenuItem,
-			this.volumeBalanceMiddleToolStripMenuItem,
-			this.volumeBalanceRightToolStripMenuItem,
-			this.toolStripSeparator3,
-			this.volumeBalanceByWindowsPosToolStripMenuItem});
+            this.volumeUpToolStripMenuItem,
+            this.volumeDownToolStripMenuItem,
+            this.muteToolStripMenuItem,
+            this.volumeToolStripSeparator,
+            this.volumeBalanceLeftToolStripMenuItem,
+            this.volumeBalanceMiddleToolStripMenuItem,
+            this.volumeBalanceRightToolStripMenuItem,
+            this.toolStripSeparator3,
+            this.volumeBalanceByWindowsPosToolStripMenuItem});
 			this.volumeToolStripMenuItem.Name = "volumeToolStripMenuItem";
 			this.volumeToolStripMenuItem.Size = new System.Drawing.Size(153, 22);
 			this.volumeToolStripMenuItem.Text = "音量";

--- a/src/PeerstPlayer/Forms/Player/PlayerView.Designer.cs
+++ b/src/PeerstPlayer/Forms/Player/PlayerView.Designer.cs
@@ -86,10 +86,12 @@ namespace PeerstPlayer.Forms.Setting
 			this.volumeBalanceLeftToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.volumeBalanceMiddleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.volumeBalanceRightToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.volumeBalanceByWindowsPosToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.settingToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.wmpMenuToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
 			this.wmpMenuToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.showDebugToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
 			this.toolStrip.SuspendLayout();
 			this.contextMenuStrip.SuspendLayout();
 			this.SuspendLayout();
@@ -102,10 +104,10 @@ namespace PeerstPlayer.Forms.Setting
 			this.toolStrip.Dock = System.Windows.Forms.DockStyle.None;
 			this.toolStrip.GripMargin = new System.Windows.Forms.Padding(0);
 			this.toolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.openViewerToolStripButton,
-            this.minToolStripButton,
-            this.maxToolStripButton,
-            this.closeToolStripButton});
+			this.openViewerToolStripButton,
+			this.minToolStripButton,
+			this.maxToolStripButton,
+			this.closeToolStripButton});
 			this.toolStrip.Location = new System.Drawing.Point(381, 0);
 			this.toolStrip.Name = "toolStrip";
 			this.toolStrip.Padding = new System.Windows.Forms.Padding(0);
@@ -193,34 +195,34 @@ namespace PeerstPlayer.Forms.Setting
 			// contextMenuStrip
 			// 
 			this.contextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.SizeToolStripMenuItem,
-            this.画面分割ToolStripMenuItem,
-            this.functionToolStripMenuItem,
-            this.volumeToolStripMenuItem,
-            this.settingToolStripMenuItem,
-            this.wmpMenuToolStripSeparator,
-            this.wmpMenuToolStripMenuItem,
-            this.showDebugToolStripMenuItem});
+			this.SizeToolStripMenuItem,
+			this.画面分割ToolStripMenuItem,
+			this.functionToolStripMenuItem,
+			this.volumeToolStripMenuItem,
+			this.settingToolStripMenuItem,
+			this.wmpMenuToolStripSeparator,
+			this.wmpMenuToolStripMenuItem,
+			this.showDebugToolStripMenuItem});
 			this.contextMenuStrip.Name = "contextMenuStrip";
 			this.contextMenuStrip.Size = new System.Drawing.Size(154, 186);
 			// 
 			// SizeToolStripMenuItem
 			// 
 			this.SizeToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.scale25PerToolStripMenuItem,
-            this.scale50PerToolStripMenuItem,
-            this.scale75PerToolStripMenuItem,
-            this.scale100PerToolStripMenuItem,
-            this.scale150PerToolStripMenuItem,
-            this.scale200PerToolStripMenuItem,
-            this.sizeToolStripSeparator,
-            this.size160x120ToolStripMenuItem,
-            this.size320x240ToolStripMenuItem,
-            this.size480x360ToolStripMenuItem,
-            this.size640x480ToolStripMenuItem,
-            this.size800x600ToolStripMenuItem,
-            this.fitMovieSizeToolStripSeparator,
-            this.fitMovieSizeToolStripMenuItem});
+			this.scale25PerToolStripMenuItem,
+			this.scale50PerToolStripMenuItem,
+			this.scale75PerToolStripMenuItem,
+			this.scale100PerToolStripMenuItem,
+			this.scale150PerToolStripMenuItem,
+			this.scale200PerToolStripMenuItem,
+			this.sizeToolStripSeparator,
+			this.size160x120ToolStripMenuItem,
+			this.size320x240ToolStripMenuItem,
+			this.size480x360ToolStripMenuItem,
+			this.size640x480ToolStripMenuItem,
+			this.size800x600ToolStripMenuItem,
+			this.fitMovieSizeToolStripSeparator,
+			this.fitMovieSizeToolStripMenuItem});
 			this.SizeToolStripMenuItem.Name = "SizeToolStripMenuItem";
 			this.SizeToolStripMenuItem.Size = new System.Drawing.Size(153, 22);
 			this.SizeToolStripMenuItem.Text = "サイズ";
@@ -310,15 +312,15 @@ namespace PeerstPlayer.Forms.Setting
 			// 画面分割ToolStripMenuItem
 			// 
 			this.画面分割ToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.screenSplitWidthx5ToolStripMenuItem,
-            this.screenSplitWidthx4ToolStripMenuItem,
-            this.screenSplitWidthx3ToolStripMenuItem,
-            this.screenSplitWidthx2ToolStripMenuItem,
-            this.screenSplitToolStripSeparator,
-            this.screenSplitHeightx5ToolStripMenuItem,
-            this.screenSplitHeightx4ToolStripMenuItem,
-            this.screenSplitHeightx3ToolStripMenuItem,
-            this.screenSplitHeightx2ToolStripMenuItem});
+			this.screenSplitWidthx5ToolStripMenuItem,
+			this.screenSplitWidthx4ToolStripMenuItem,
+			this.screenSplitWidthx3ToolStripMenuItem,
+			this.screenSplitWidthx2ToolStripMenuItem,
+			this.screenSplitToolStripSeparator,
+			this.screenSplitHeightx5ToolStripMenuItem,
+			this.screenSplitHeightx4ToolStripMenuItem,
+			this.screenSplitHeightx3ToolStripMenuItem,
+			this.screenSplitHeightx2ToolStripMenuItem});
 			this.画面分割ToolStripMenuItem.Name = "画面分割ToolStripMenuItem";
 			this.画面分割ToolStripMenuItem.Size = new System.Drawing.Size(153, 22);
 			this.画面分割ToolStripMenuItem.Text = "画面分割";
@@ -379,16 +381,16 @@ namespace PeerstPlayer.Forms.Setting
 			// functionToolStripMenuItem
 			// 
 			this.functionToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.topMostToolStripMenuItem,
-            this.updateChannelInfoToolStripMenuItem,
-            this.bumpToolStripMenuItem,
-            this.toolStripSeparator1,
-            this.screenshotToolStripMenuItem,
-            this.openScreenshotFolderToolStripMenuItem,
-            this.toolStripSeparator2,
-            this.openFromUrlToolStripMenuItem,
-            this.openFromFileToolStripMenuItem,
-            this.openFromClipboardToolStripMenuItem});
+			this.topMostToolStripMenuItem,
+			this.updateChannelInfoToolStripMenuItem,
+			this.bumpToolStripMenuItem,
+			this.toolStripSeparator1,
+			this.screenshotToolStripMenuItem,
+			this.openScreenshotFolderToolStripMenuItem,
+			this.toolStripSeparator2,
+			this.openFromUrlToolStripMenuItem,
+			this.openFromFileToolStripMenuItem,
+			this.openFromClipboardToolStripMenuItem});
 			this.functionToolStripMenuItem.Name = "functionToolStripMenuItem";
 			this.functionToolStripMenuItem.Size = new System.Drawing.Size(153, 22);
 			this.functionToolStripMenuItem.Text = "機能";
@@ -437,7 +439,7 @@ namespace PeerstPlayer.Forms.Setting
 			// openFromUrlToolStripMenuItem
 			// 
 			this.openFromUrlToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.openFromUrlToolStripTextBox});
+			this.openFromUrlToolStripTextBox});
 			this.openFromUrlToolStripMenuItem.Name = "openFromUrlToolStripMenuItem";
 			this.openFromUrlToolStripMenuItem.Size = new System.Drawing.Size(268, 22);
 			this.openFromUrlToolStripMenuItem.Text = "URLから開く";
@@ -465,13 +467,15 @@ namespace PeerstPlayer.Forms.Setting
 			// volumeToolStripMenuItem
 			// 
 			this.volumeToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.volumeUpToolStripMenuItem,
-            this.volumeDownToolStripMenuItem,
-            this.muteToolStripMenuItem,
-            this.volumeToolStripSeparator,
-            this.volumeBalanceLeftToolStripMenuItem,
-            this.volumeBalanceMiddleToolStripMenuItem,
-            this.volumeBalanceRightToolStripMenuItem});
+			this.volumeUpToolStripMenuItem,
+			this.volumeDownToolStripMenuItem,
+			this.muteToolStripMenuItem,
+			this.volumeToolStripSeparator,
+			this.volumeBalanceLeftToolStripMenuItem,
+			this.volumeBalanceMiddleToolStripMenuItem,
+			this.volumeBalanceRightToolStripMenuItem,
+			this.toolStripSeparator3,
+			this.volumeBalanceByWindowsPosToolStripMenuItem});
 			this.volumeToolStripMenuItem.Name = "volumeToolStripMenuItem";
 			this.volumeToolStripMenuItem.Size = new System.Drawing.Size(153, 22);
 			this.volumeToolStripMenuItem.Text = "音量";
@@ -479,43 +483,49 @@ namespace PeerstPlayer.Forms.Setting
 			// volumeUpToolStripMenuItem
 			// 
 			this.volumeUpToolStripMenuItem.Name = "volumeUpToolStripMenuItem";
-			this.volumeUpToolStripMenuItem.Size = new System.Drawing.Size(160, 22);
+			this.volumeUpToolStripMenuItem.Size = new System.Drawing.Size(292, 22);
 			this.volumeUpToolStripMenuItem.Text = "上げる";
 			// 
 			// volumeDownToolStripMenuItem
 			// 
 			this.volumeDownToolStripMenuItem.Name = "volumeDownToolStripMenuItem";
-			this.volumeDownToolStripMenuItem.Size = new System.Drawing.Size(160, 22);
+			this.volumeDownToolStripMenuItem.Size = new System.Drawing.Size(292, 22);
 			this.volumeDownToolStripMenuItem.Text = "下げる";
 			// 
 			// muteToolStripMenuItem
 			// 
 			this.muteToolStripMenuItem.Name = "muteToolStripMenuItem";
-			this.muteToolStripMenuItem.Size = new System.Drawing.Size(160, 22);
+			this.muteToolStripMenuItem.Size = new System.Drawing.Size(292, 22);
 			this.muteToolStripMenuItem.Text = "ミュート";
 			// 
 			// volumeToolStripSeparator
 			// 
 			this.volumeToolStripSeparator.Name = "volumeToolStripSeparator";
-			this.volumeToolStripSeparator.Size = new System.Drawing.Size(157, 6);
+			this.volumeToolStripSeparator.Size = new System.Drawing.Size(289, 6);
 			// 
 			// volumeBalanceLeftToolStripMenuItem
 			// 
 			this.volumeBalanceLeftToolStripMenuItem.Name = "volumeBalanceLeftToolStripMenuItem";
-			this.volumeBalanceLeftToolStripMenuItem.Size = new System.Drawing.Size(160, 22);
+			this.volumeBalanceLeftToolStripMenuItem.Size = new System.Drawing.Size(292, 22);
 			this.volumeBalanceLeftToolStripMenuItem.Text = "バランス：左";
 			// 
 			// volumeBalanceMiddleToolStripMenuItem
 			// 
 			this.volumeBalanceMiddleToolStripMenuItem.Name = "volumeBalanceMiddleToolStripMenuItem";
-			this.volumeBalanceMiddleToolStripMenuItem.Size = new System.Drawing.Size(160, 22);
+			this.volumeBalanceMiddleToolStripMenuItem.Size = new System.Drawing.Size(292, 22);
 			this.volumeBalanceMiddleToolStripMenuItem.Text = "バランス：中央";
 			// 
 			// volumeBalanceRightToolStripMenuItem
 			// 
 			this.volumeBalanceRightToolStripMenuItem.Name = "volumeBalanceRightToolStripMenuItem";
-			this.volumeBalanceRightToolStripMenuItem.Size = new System.Drawing.Size(160, 22);
+			this.volumeBalanceRightToolStripMenuItem.Size = new System.Drawing.Size(292, 22);
 			this.volumeBalanceRightToolStripMenuItem.Text = "バランス：右";
+			// 
+			// volumeBalanceByWindowsPosToolStripMenuItem
+			// 
+			this.volumeBalanceByWindowsPosToolStripMenuItem.Name = "volumeBalanceByWindowsPosToolStripMenuItem";
+			this.volumeBalanceByWindowsPosToolStripMenuItem.Size = new System.Drawing.Size(292, 22);
+			this.volumeBalanceByWindowsPosToolStripMenuItem.Text = "ウィンドウ位置に応じてバランスを変更";
 			// 
 			// settingToolStripMenuItem
 			// 
@@ -539,6 +549,11 @@ namespace PeerstPlayer.Forms.Setting
 			this.showDebugToolStripMenuItem.Name = "showDebugToolStripMenuItem";
 			this.showDebugToolStripMenuItem.Size = new System.Drawing.Size(153, 22);
 			this.showDebugToolStripMenuItem.Text = "動画情報表示";
+			// 
+			// toolStripSeparator3
+			// 
+			this.toolStripSeparator3.Name = "toolStripSeparator3";
+			this.toolStripSeparator3.Size = new System.Drawing.Size(289, 6);
 			// 
 			// PlayerView
 			// 
@@ -619,6 +634,8 @@ namespace PeerstPlayer.Forms.Setting
 		private System.Windows.Forms.ToolStripTextBox openFromUrlToolStripTextBox;
 		private System.Windows.Forms.ToolStripMenuItem openFromClipboardToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem showDebugToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem volumeBalanceByWindowsPosToolStripMenuItem;
+		private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
 	}
 }
 

--- a/src/PeerstPlayer/Forms/Player/PlayerView.cs
+++ b/src/PeerstPlayer/Forms/Player/PlayerView.cs
@@ -557,7 +557,7 @@ namespace PeerstPlayer.Forms.Setting
 			volumeBalanceLeftToolStripMenuItem.Click += (sender, e) => shortcut.ExecCommand(Commands.VolumeBalanceLeft);
 			volumeBalanceMiddleToolStripMenuItem.Click += (sender, e) => shortcut.ExecCommand(Commands.VolumeBalanceMiddle);
 			volumeBalanceRightToolStripMenuItem.Click += (sender, e) => shortcut.ExecCommand(Commands.VolumeBalanceRight);
-			volumeBalanceByWindowsPosToolStripMenuItem.Click += (sender, e) => { pecaPlayer.VolumeBalanceByWindowPos = !pecaPlayer.VolumeBalanceByWindowPos; };
+			volumeBalanceByWindowsPosToolStripMenuItem.Click += (sender, e) => shortcut.ExecCommand(Commands.VolumeBalanceByWindowPos);
 			volumeToolStripMenuItem.DropDownOpening += (sender, e) => muteToolStripMenuItem.Checked = pecaPlayer.Mute;
 			volumeToolStripMenuItem.DropDownOpening += (sender, e) => volumeBalanceLeftToolStripMenuItem.Checked = (pecaPlayer.VolumeBalance == VolumeBalanceCommandArgs.BalanceLeft);
 			volumeToolStripMenuItem.DropDownOpening += (sender, e) => volumeBalanceMiddleToolStripMenuItem.Checked = (pecaPlayer.VolumeBalance == VolumeBalanceCommandArgs.BalanceMiddle);

--- a/src/PeerstPlayer/Forms/Player/PlayerView.cs
+++ b/src/PeerstPlayer/Forms/Player/PlayerView.cs
@@ -458,6 +458,14 @@ namespace PeerstPlayer.Forms.Setting
 				}
 			};
 
+			// 位置変更
+			LocationChanged += (sender, e) =>
+			{
+				var width = Screen.PrimaryScreen.Bounds.Width;
+
+				pecaPlayer.VolumeBalance = (Location.X - width / 2) * 100 / width;
+			};
+
 			//-----------------------------------------------------
 			// コンテキストメニュー
 			//-----------------------------------------------------
@@ -616,5 +624,6 @@ namespace PeerstPlayer.Forms.Setting
 				return param;
 			}
 		}
+
 	}
 }

--- a/src/PeerstPlayer/Forms/Player/PlayerView.cs
+++ b/src/PeerstPlayer/Forms/Player/PlayerView.cs
@@ -458,13 +458,10 @@ namespace PeerstPlayer.Forms.Setting
 				}
 			};
 
-			// ウィンドウ位置に応じて音量バランス変更
-			var VolumeBalanceByWindowPos = false;   // この変数保持する場所募集中
-
 			// 位置変更
 			LocationChanged += (sender, e) =>
 			{
-				if (VolumeBalanceByWindowPos)
+				if (pecaPlayer.VolumeBalanceByWindowPos)
 				{
 					var screenWidth = Screen.PrimaryScreen.Bounds.Width;
 					var windowCenter = Location.X + Width / 2;
@@ -560,12 +557,12 @@ namespace PeerstPlayer.Forms.Setting
 			volumeBalanceLeftToolStripMenuItem.Click += (sender, e) => shortcut.ExecCommand(Commands.VolumeBalanceLeft);
 			volumeBalanceMiddleToolStripMenuItem.Click += (sender, e) => shortcut.ExecCommand(Commands.VolumeBalanceMiddle);
 			volumeBalanceRightToolStripMenuItem.Click += (sender, e) => shortcut.ExecCommand(Commands.VolumeBalanceRight);
-			volumeBalanceByWindowsPosToolStripMenuItem.Click += (sender, e) => { VolumeBalanceByWindowPos = !VolumeBalanceByWindowPos; };
+			volumeBalanceByWindowsPosToolStripMenuItem.Click += (sender, e) => { pecaPlayer.VolumeBalanceByWindowPos = !pecaPlayer.VolumeBalanceByWindowPos; };
 			volumeToolStripMenuItem.DropDownOpening += (sender, e) => muteToolStripMenuItem.Checked = pecaPlayer.Mute;
 			volumeToolStripMenuItem.DropDownOpening += (sender, e) => volumeBalanceLeftToolStripMenuItem.Checked = (pecaPlayer.VolumeBalance == VolumeBalanceCommandArgs.BalanceLeft);
 			volumeToolStripMenuItem.DropDownOpening += (sender, e) => volumeBalanceMiddleToolStripMenuItem.Checked = (pecaPlayer.VolumeBalance == VolumeBalanceCommandArgs.BalanceMiddle);
 			volumeToolStripMenuItem.DropDownOpening += (sender, e) => volumeBalanceRightToolStripMenuItem.Checked = (pecaPlayer.VolumeBalance == VolumeBalanceCommandArgs.BalanceRight);
-			volumeToolStripMenuItem.DropDownOpening += (sender, e) => volumeBalanceByWindowsPosToolStripMenuItem.Checked = VolumeBalanceByWindowPos;
+			volumeToolStripMenuItem.DropDownOpening += (sender, e) => volumeBalanceByWindowsPosToolStripMenuItem.Checked = pecaPlayer.VolumeBalanceByWindowPos;
 
 			// 設定メニュー押下
 			settingToolStripMenuItem.Click += (sender, e) =>

--- a/src/PeerstPlayer/Forms/Player/PlayerView.cs
+++ b/src/PeerstPlayer/Forms/Player/PlayerView.cs
@@ -458,13 +458,20 @@ namespace PeerstPlayer.Forms.Setting
 				}
 			};
 
+			// ウィンドウ位置に応じて音量バランス変更
+			var VolumeBalanceByWindowPos = false;   // この変数保持する場所募集中
+
 			// 位置変更
 			LocationChanged += (sender, e) =>
 			{
-				var screenWidth = Screen.PrimaryScreen.Bounds.Width;
-				var windowCenter = Location.X + Width / 2;
+				if (VolumeBalanceByWindowPos)
+				{
+					var screenWidth = Screen.PrimaryScreen.Bounds.Width;
+					var windowCenter = Location.X + Width / 2;
 
-				pecaPlayer.VolumeBalance = (windowCenter - screenWidth / 2) * 100 / screenWidth;
+					// 音量バランスを変更
+					pecaPlayer.VolumeBalance = (windowCenter - screenWidth / 2) * 100 / screenWidth;
+				}
 			};
 
 			//-----------------------------------------------------
@@ -553,10 +560,12 @@ namespace PeerstPlayer.Forms.Setting
 			volumeBalanceLeftToolStripMenuItem.Click += (sender, e) => shortcut.ExecCommand(Commands.VolumeBalanceLeft);
 			volumeBalanceMiddleToolStripMenuItem.Click += (sender, e) => shortcut.ExecCommand(Commands.VolumeBalanceMiddle);
 			volumeBalanceRightToolStripMenuItem.Click += (sender, e) => shortcut.ExecCommand(Commands.VolumeBalanceRight);
+			volumeBalanceByWindowsPosToolStripMenuItem.Click += (sender, e) => { VolumeBalanceByWindowPos = !VolumeBalanceByWindowPos; };
 			volumeToolStripMenuItem.DropDownOpening += (sender, e) => muteToolStripMenuItem.Checked = pecaPlayer.Mute;
 			volumeToolStripMenuItem.DropDownOpening += (sender, e) => volumeBalanceLeftToolStripMenuItem.Checked = (pecaPlayer.VolumeBalance == VolumeBalanceCommandArgs.BalanceLeft);
 			volumeToolStripMenuItem.DropDownOpening += (sender, e) => volumeBalanceMiddleToolStripMenuItem.Checked = (pecaPlayer.VolumeBalance == VolumeBalanceCommandArgs.BalanceMiddle);
 			volumeToolStripMenuItem.DropDownOpening += (sender, e) => volumeBalanceRightToolStripMenuItem.Checked = (pecaPlayer.VolumeBalance == VolumeBalanceCommandArgs.BalanceRight);
+			volumeToolStripMenuItem.DropDownOpening += (sender, e) => volumeBalanceByWindowsPosToolStripMenuItem.Checked = VolumeBalanceByWindowPos;
 
 			// 設定メニュー押下
 			settingToolStripMenuItem.Click += (sender, e) =>

--- a/src/PeerstPlayer/Forms/Player/PlayerView.cs
+++ b/src/PeerstPlayer/Forms/Player/PlayerView.cs
@@ -461,9 +461,10 @@ namespace PeerstPlayer.Forms.Setting
 			// 位置変更
 			LocationChanged += (sender, e) =>
 			{
-				var width = Screen.PrimaryScreen.Bounds.Width;
+				var screenWidth = Screen.PrimaryScreen.Bounds.Width;
+				var windowCenter = Location.X + Width / 2;
 
-				pecaPlayer.VolumeBalance = (Location.X - width / 2) * 100 / width;
+				pecaPlayer.VolumeBalance = (windowCenter - screenWidth / 2) * 100 / screenWidth;
 			};
 
 			//-----------------------------------------------------

--- a/src/PeerstPlayer/PeerstPlayer.csproj
+++ b/src/PeerstPlayer/PeerstPlayer.csproj
@@ -138,6 +138,7 @@
     <Compile Include="Shortcut\Command\TopMostCommand.cs" />
     <Compile Include="Shortcut\Command\UpdateChannelInfoCommand.cs" />
     <Compile Include="Shortcut\Command\VisibleStatusBarCommand.cs" />
+    <Compile Include="Shortcut\Command\VolumeBalanceByWindowPos.cs" />
     <Compile Include="Shortcut\Command\VolumeBalanceCommand.cs" />
     <Compile Include="Shortcut\Command\VolumeDownCommand.cs" />
     <Compile Include="Shortcut\Command\VolumeUpCommand.cs" />

--- a/src/PeerstPlayer/Shortcut/Command/VolumeBalanceByWindowPos.cs
+++ b/src/PeerstPlayer/Shortcut/Command/VolumeBalanceByWindowPos.cs
@@ -1,0 +1,27 @@
+﻿using PeerstPlayer.Controls.PecaPlayer;
+
+namespace PeerstPlayer.Shortcut.Command
+{
+    /// <summary>
+    /// 自動バランス調整切り替えコマンド
+    /// </summary>
+    class VolumeBalanceByWindowPosCommand : IShortcutCommand
+    {
+        private PecaPlayerControl pecaPlayer;
+
+        public VolumeBalanceByWindowPosCommand(PecaPlayerControl pecaPlayer)
+        {
+            this.pecaPlayer = pecaPlayer;
+        }
+
+        public void Execute(CommandArgs commandArgs)
+        {
+            pecaPlayer.VolumeBalanceByWindowPos = !pecaPlayer.VolumeBalanceByWindowPos;
+        }
+
+        string IShortcutCommand.GetDetail(CommandArgs commandArgs)
+        {
+            return "音量バランス：ウィンドウ位置に応じて変更";
+        }
+    }
+}

--- a/src/PeerstPlayer/Shortcut/Commands.cs
+++ b/src/PeerstPlayer/Shortcut/Commands.cs
@@ -10,6 +10,7 @@ namespace PeerstPlayer.Shortcut
 		VolumeBalanceLeft,	// 音量バランス：左
 		VolumeBalanceMiddle,// 音量バランス：中央
 		VolumeBalanceRight,	// 音量バランス：右
+		VolumeBalanceByWindowPos,// ウィンドウ位置に応じて音量バランスを変更
 		Mute,				// ミュート切り替え
 		WindowMaximize,		// ウィンドウ最大化
 		WindowMinimize,		// ウィンドウ最小化

--- a/src/PeerstPlayer/Shortcut/ShortcutManager.cs
+++ b/src/PeerstPlayer/Shortcut/ShortcutManager.cs
@@ -201,6 +201,7 @@ namespace PeerstPlayer.Shortcut
 				{	Commands.VolumeBalanceLeft,		new ShortcutCommand(new VolumeBalanceCommand(pecaPlayer), new VolumeBalanceCommandArgs(VolumeBalanceCommandArgs.BalanceLeft))	}, // 音量バランス：左
 				{	Commands.VolumeBalanceMiddle,	new ShortcutCommand(new VolumeBalanceCommand(pecaPlayer), new VolumeBalanceCommandArgs(VolumeBalanceCommandArgs.BalanceMiddle))	}, // 音量バランス：中央
 				{	Commands.VolumeBalanceRight,	new ShortcutCommand(new VolumeBalanceCommand(pecaPlayer), new VolumeBalanceCommandArgs(VolumeBalanceCommandArgs.BalanceRight))	}, // 音量バランス：右
+				{	Commands.VolumeBalanceByWindowPos,new ShortcutCommand(new VolumeBalanceByWindowPosCommand(pecaPlayer), new CommandArgs())	        }, // 音量バランス：ウィンドウ位置に応じて変更
 				{	Commands.Mute,					new ShortcutCommand(new MuteCommand(pecaPlayer), new CommandArgs())									}, // ミュート切替
 				{	Commands.WindowMinimize,		new ShortcutCommand(new WindowMinimize(form), new CommandArgs())									}, // ウィンドウを最小化
 				{	Commands.WindowMaximize,		new ShortcutCommand(new WindowMaximize(form), new CommandArgs())									}, // ウィンドウを最大化


### PR DESCRIPTION
変更点
・右クリックメニューに｢音量－ウィンドウ位置に応じてバランスを変更」を追加
　チェックすると、ウィンドウを移動したときに音量バランスが自動的に変更されます。
・PlayerViewクラスにイベントメソッドを追加
・PecaPlayerクラスのプロパティとショートカットコマンドを追加

ぷろぐれ先生の発案です。