### PR TITLE
FLVのタイプ判定を大文字小文字区別しないように変更した

### DIFF
--- a/src/PeerstPlayer/Controls/PecaPlayer/PecaPlayer.cs
+++ b/src/PeerstPlayer/Controls/PecaPlayer/PecaPlayer.cs
@@ -253,7 +253,7 @@ namespace PeerstPlayer.Controls.PecaPlayer
 
 			this.SuspendLayout();
 			string[] commandLineArgs = Environment.GetCommandLineArgs();
-			if (commandLineArgs.Length > 2 && commandLineArgs[2] == "FLV")
+			if (commandLineArgs.Length > 2 && string.Equals(commandLineArgs[2], "FLV", StringComparison.OrdinalIgnoreCase))
 			{
 				moviePlayer = new FlashMoviePlayerControl(this);
 			}


### PR DESCRIPTION
Peercastの形式のところが小文字になっている場合があるらしいので、区別しないようにしました。